### PR TITLE
Fix length of null array bug

### DIFF
--- a/App.js
+++ b/App.js
@@ -73,7 +73,7 @@ export default class App extends Component<{}> {
     this.onReceived = ChirpConnectEmitter.addListener(
       'onReceived',
       (event) => {
-        if (event.data) {
+        if (event.data.length) {
           this.setState({ data: event.data });
         }
       }

--- a/android/app/src/main/java/com/chirpreactnative/RCTChirpConnectModule.java
+++ b/android/app/src/main/java/com/chirpreactnative/RCTChirpConnectModule.java
@@ -250,8 +250,10 @@ public class RCTChirpConnectModule extends ReactContextBaseJavaModule implements
 
     private static WritableMap assembleData(byte[] data) {
         WritableArray payload = Arguments.createArray();
-        for (int i = 0; i < data.length; i++) {
-            payload.pushInt(data[i]);
+        if (data != null) {
+            for (int i = 0; i < data.length; i++) {
+                payload.pushInt(data[i]);
+            }
         }
         WritableMap params = Arguments.createMap();
         params.putArray("data", payload);


### PR DESCRIPTION
Who: @rajaishwary
Why: Crashes on a failed decode
What:

Check if data is null before attempting to unpack into a WritableArray